### PR TITLE
Swap out ethcore.io url

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ of RPC APIs.
 If you run into an issue while using parity, feel free to file one in this repository
 or hop on our [gitter chat room][gitter-url] to ask a question. We are glad to help!
 
-Parity's current release is 1.5. You can download it at https://ethcore.io/parity.html or follow the instructions
+Parity's current release is 1.5. You can download it at https://parity.io or follow the instructions
 below to build from source.
 
 ----


### PR DESCRIPTION
It throws a certificate error on HTTPS because the certificate is only valid on parity.io.